### PR TITLE
Correct the numbering of Short Trek episodes

### DIFF
--- a/chronological_star_trek/index.html
+++ b/chronological_star_trek/index.html
@@ -515,7 +515,7 @@
 							<p>This marks the first appearance of a <cite>Short Treks</cite> episode. As the episodes of this series by design jump all around in <cite>Star Trek</cite> history and aren't designed to be watched sequentially as one ongoing story like a traditional series, they will appear scattered throughout the timeline.</p>
 							<dl>
 								<dt><cite>The Girl Who Made the Stars</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 8</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 5</dd>
 							</dl>
 							<aside>
 								<p>The exact year cannot be determined. Michael Burnham was born in 2226. When the character appears in 2236 in <cite>Brother</cite> it makes it clear that Burnham in <cite>The Girl Who Made the Stars</cite> falls somewhere in between in age, so early 2230's seems a fair approximation.</p>
@@ -528,7 +528,7 @@
 							<h3>2254</h3>
 							<dl>
 								<dt><cite>Q&amp;A</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 5</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 1</dd>
 								<dt><cite>The Cage</cite></dt>
 								<dd><cite>Star Trek</cite> season 0 episode 1</dd>
 							</dl>
@@ -620,9 +620,9 @@
 							<h3>Late 2250's</h3>
 							<dl>
 								<dt><cite>The Trouble with Edward</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 6</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 2</dd>
 								<dt><cite>Ask Not</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 7</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 3</dd>
 							</dl>
 							<aside>
 								<p>The dates of these two <cite>Short Treks</cite> episodes are impossible to exactly determine. But since they aired between <cite>Discovery</cite> season 2 (2258) and <cite>Strange New Worlds</cite> season 1 (2259), late 2250's (meaning either later in 2258 or early in 2259) will have to do as an approximation.</p>
@@ -952,7 +952,7 @@
 								<dt><cite>Star Trek III: The Search for Spock</cite></dt>
 								<dd><cite>Star Trek</cite> film 3</dd>
 								<dt><cite>Ephraim and Dot</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 9</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 4</dd>
 							</dl>
 							<aside>
 								<p><cite>Ephraim and Dot</cite> shows a series of events from <cite>The Naked Time</cite> through <cite>Star Trek III</cite>, so placing it after <cite>Star Trek III</cite> seems as good a place as any.</p>
@@ -2436,7 +2436,7 @@
 								<dt><cite>Ouroboros, Part II</cite></dt>
 								<dd><cite>Prodigy</cite> season 2 episode 20</dd>
 								<dt><cite>Children of Mars</cite></dt>
-								<dd><cite>Short Treks</cite> season 1 episode 10</dd>
+								<dd><cite>Short Treks</cite> season 2 episode 6</dd>
 							</dl>
 							<aside>
 								<p>Technically of course, <cite>Children of Mars</cite> occurs inside the events of <cite>Ouroboros, Part II</cite>.</p>


### PR DESCRIPTION
According to Memory Alpha[1], the changed episodes in this commit belong to the second season of Short Treks.

https://memory-alpha.fandom.com/wiki/Star_Trek:_Short_Treks

I hope you don't mind this random passerby PR, but I came across your chronological listing, and this jumped out at me.